### PR TITLE
Add Travis CI to the list of CI/CD providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Codefresh [Codefresh](http://codefresh.io/) (Docker-based continuous integration
 
 [Shippable](https://app.shippable.com/) (automated DevOps with Docker)
 
-[Travis CI](https://travis-ci.org) (continuous integration and delivery platform built on Docker and supporting Docker-based build and deployment workflow)
+[Travis CI](https://travis-ci.org) (Docker-based continuous integration and delivery)
 
 [Wercker](http://wercker.com/) (Docker-based dev, build and deploy automation)
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Codefresh [Codefresh](http://codefresh.io/) (Docker-based continuous integration
 
 [Shippable](https://app.shippable.com/) (automated DevOps with Docker)
 
+[Travis CI](https://travis-ci.org) (continuous integration and delivery platform built on Docker and supporting Docker-based build and deployment workflow)
+
 [Wercker](http://wercker.com/) (Docker-based dev, build and deploy automation)
 
 XebiaLabs [Overcast](https://github.com/xebialabs/overcast) (Docker for integration testing with other services)


### PR DESCRIPTION
For reference: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/ and http://blog.travis-ci.com/2015-08-19-using-docker-on-travis-ci/

Thank you for your consideration, and please let me know if I've missed anything or something's off! :heart:
